### PR TITLE
Fix the test for incoming LTS 2.332

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/config/GitHubServerConfigTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.net.URI;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.jenkinsci.plugins.github.config.GitHubServerConfig.GITHUB_URL;
@@ -74,7 +75,7 @@ public class GitHubServerConfigTest {
         GitHubServerConfig input = new GitHubServerConfig("");
         input.setApiUrl(CUSTOM_GH_SERVER);
         assertThat(input.getName(), is(nullValue()));
-        assertThat(input.getDisplayName(), is("some (http://some.com)"));
+        assertThat(input.getDisplayName(), containsString("http://some.com"));
     }
 
     @Test


### PR DESCRIPTION
Fixes:
```
[ERROR] Failures: 
[ERROR]   GitHubServerConfigTest.shouldGuessNameIfNotProvided:77 
Expected: is "some (http://some.com)"
     but: was "http://some.com"
```
by using `mvn clean install -Djenkins.version=2.332`